### PR TITLE
fix remark priority when summing tx per address

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -98,6 +98,7 @@ class App extends Component {
             hash: []};
         }
         acc[cur.from].value = cur.value.add(acc[cur.from].value);
+        acc[cur.from].input = cur.input !== '0x' ? cur.input : acc[cur.from].input;
         acc[cur.from].hash.push(cur.hash);
         return acc;
       }, {});

--- a/src/App.js
+++ b/src/App.js
@@ -98,7 +98,7 @@ class App extends Component {
             hash: []};
         }
         acc[cur.from].value = cur.value.add(acc[cur.from].value);
-        acc[cur.from].input = cur.input !== '0x' ? cur.input : acc[cur.from].input;
+        acc[cur.from].input = cur.input !== '0x' && cur.input !== '0x00' ? cur.input : acc[cur.from].input;
         acc[cur.from].hash.push(cur.hash);
         return acc;
       }, {});


### PR DESCRIPTION
Per #9, fix 'remark' field when summing transaction values per address.

As @geleeroyale specifies: 

> Flow:
> 
> 1 - ignore all standard input (should be 0x)
> 2 - display the first 'remark' found
> 3 - go through later transactions
> 3 - if there is a newer 'remark' found use that for display